### PR TITLE
fix: correct mapping of DCAT themes to groups

### DIFF
--- a/ckanext/custom_harvest/configuration_processors.py
+++ b/ckanext/custom_harvest/configuration_processors.py
@@ -132,10 +132,18 @@ class DefaultGroups(BaseConfigProcessor):
         if default_groups:
             if 'groups' not in package_dict:
                 package_dict['groups'] = []
-            existing_group_ids = [g['id'] for g in package_dict['groups']]
+            existing_ids = set()
+            existing_names = set()
+            for group in package_dict['groups']:
+                group_id = group.get('id')
+                if group_id:
+                    existing_ids.add(group_id)
+                group_name = group.get('name')
+                if group_name:
+                    existing_names.add(group_name)
             package_dict['groups'].extend(
                 [{'name': g['name']} for g in config['default_group_dicts']
-                 if g['id'] not in existing_group_ids])
+                 if g['id'] not in existing_ids and g['name'] not in existing_names])
 
 
 class DefaultExtras(BaseConfigProcessor):
@@ -448,7 +456,7 @@ class RemoteGroups(BaseConfigProcessor):
         validated_groups = []
 
         existing_groups = get_action('group_list')({}, {'all_fields': True})
-        for source_group in source_dict['groups']:
+        for source_group in source_dict.get('groups', []):
             found_group = False
             for existing_group in existing_groups:
                 # Found local group

--- a/ckanext/custom_harvest/configuration_processors.py
+++ b/ckanext/custom_harvest/configuration_processors.py
@@ -452,8 +452,9 @@ class RemoteGroups(BaseConfigProcessor):
         if 'groups' not in package_dict:
             package_dict['groups'] = []
 
-        # check if remote groups exist locally
-        validated_groups = []
+        # Key by canonical group name so duplicate source entries (e.g. themes that
+        # munge to the same slug) produce a single package group assignment.
+        validated_groups = {}
 
         existing_groups = get_action('group_list')({}, {'all_fields': True})
         for source_group in source_dict.get('groups', []):
@@ -464,7 +465,8 @@ class RemoteGroups(BaseConfigProcessor):
                 name_match = (source_group.get('name') == existing_group.get('name'))
                 if title_match or name_match:
                     found_group = True
-                    validated_groups.append({'id': existing_group['id'], 'name': existing_group['name']})
+                    group_name = existing_group['name']
+                    validated_groups[group_name] = {'id': existing_group['id'], 'name': group_name}
                     break
 
             if remote_groups == 'create' and not found_group:
@@ -478,11 +480,12 @@ class RemoteGroups(BaseConfigProcessor):
                         'description': source_group.get('description')
                     }
                     new_group = get_action('group_create')({'model': model, 'user': user_name}, group_dict)
-                    validated_groups.append({'id': new_group['id'], 'name': new_group['name']})
+                    group_name = new_group['name']
+                    validated_groups[group_name] = {'id': new_group['id'], 'name': group_name}
                 except Exception:
                     pass
 
-        package_dict['groups'].extend(validated_groups)
+        package_dict['groups'].extend(validated_groups.values())
 
 
 class OrganizationFilter(BaseConfigProcessor):

--- a/ckanext/custom_harvest/converter.py
+++ b/ckanext/custom_harvest/converter.py
@@ -164,24 +164,6 @@ def datagov_to_ckan(source_dict):
             if munged_tag:
                 package_dict['tags'].append({'name': munged_tag})
 
-    # Groups - Map Data.gov themes to CKAN groups
-    package_dict['groups'] = []
-
-    # Get themes from both top-level and dcat fields
-    themes = set()
-    if source_dict.get('theme'):
-        themes.update(source_dict.get('theme'))
-    if dcat.get('theme'):
-        themes.update(dcat.get('theme'))
-
-    # Convert themes to group format with slugified names
-    for theme in themes:
-        if theme:
-            # Create a slug-friendly name from the theme
-            group_name = munge_tag(theme.lower().replace(' ', '-'))
-            if group_name:
-                package_dict['groups'].append({'name': group_name})
-
     # Extras - store comprehensive metadata
     package_dict['extras'] = []
 

--- a/ckanext/custom_harvest/harvesters/datagov.py
+++ b/ckanext/custom_harvest/harvesters/datagov.py
@@ -20,9 +20,9 @@ from ckanext.custom_harvest.harvesters.package_search import copy_across_resourc
 log = logging.getLogger(__name__)
 
 
-def upload_resources_to_datastore(context, package_dict):
+def _submit_resources_to_xloader(context, package_dict):
     '''Submit tabular resources to xloader (no remote datastore field hints).'''
-    for resource in package_dict.get('resources') or []:
+    for resource in package_dict.get('resources', []):
         if utils.is_xloader_format(resource.get('format')) and resource.get('id'):
             try:
                 log.info('Submitting harvested resource {0} to be xloadered'.format(resource.get('id')))
@@ -33,7 +33,6 @@ def upload_resources_to_datastore(context, package_dict):
                 p.toolkit.get_action('xloader_submit')(context, xloader_dict)
             except p.toolkit.ValidationError as e:
                 log.debug(e)
-                pass
 
 
 def _source_groups_from_datagov_themes(source_dict):
@@ -41,7 +40,7 @@ def _source_groups_from_datagov_themes(source_dict):
     Build source_dict-style group entries from DCAT themes for RemoteGroups.
     Themes only (does not preserve any API ``groups`` on source_dict).
     '''
-    dcat = source_dict.get('dcat') or {}
+    dcat = source_dict.get('dcat', {})
     themes = set()
     if source_dict.get('theme'):
         themes.update(source_dict.get('theme'))
@@ -330,7 +329,6 @@ class DataGovHarvester(CustomHarvester):
             log.error('No harvest object received')
             return False
 
-        base_search_url = self._get_object_extra(harvest_object, 'base_search_url')
         status = self._get_object_extra(harvest_object, 'status')
 
         if status == 'delete':
@@ -449,7 +447,7 @@ class DataGovHarvester(CustomHarvester):
                 if upload_to_datastore and p.plugin_loaded('xloader'):
                     # Get package dict again in case there's new resource ids
                     pkg_dict = p.toolkit.get_action('package_show')(package_context, {'id': package_id})
-                    upload_resources_to_datastore(package_context, pkg_dict)
+                    _submit_resources_to_xloader(package_context, pkg_dict)
 
         except Exception as e:
             dataset_name = source_dict.get('slug') or source_dict.get('identifier', '')

--- a/ckanext/custom_harvest/harvesters/datagov.py
+++ b/ckanext/custom_harvest/harvesters/datagov.py
@@ -12,14 +12,49 @@ from ckan.lib.helpers import json
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 from ckanext.harvest.logic.schema import unicode_safe
 from ckanext.custom_harvest import converter
+from ckanext.custom_harvest import utils
 from ckanext.custom_harvest.harvesters.base import CustomHarvester
-from ckanext.custom_harvest.harvesters.package_search import (
-    copy_across_resource_ids,
-    upload_resources_to_datastore
-)
+from ckanext.custom_harvest.harvesters.package_search import copy_across_resource_ids
 
 
 log = logging.getLogger(__name__)
+
+
+def upload_resources_to_datastore(context, package_dict):
+    '''Submit tabular resources to xloader (no remote datastore field hints).'''
+    for resource in package_dict.get('resources') or []:
+        if utils.is_xloader_format(resource.get('format')) and resource.get('id'):
+            try:
+                log.info('Submitting harvested resource {0} to be xloadered'.format(resource.get('id')))
+                xloader_dict = {
+                    'resource_id': resource.get('id'),
+                    'ignore_hash': False
+                }
+                p.toolkit.get_action('xloader_submit')(context, xloader_dict)
+            except p.toolkit.ValidationError as e:
+                log.debug(e)
+                pass
+
+
+def _source_groups_from_datagov_themes(source_dict):
+    '''
+    Build source_dict-style group entries from DCAT themes for RemoteGroups.
+    Themes only (does not preserve any API ``groups`` on source_dict).
+    '''
+    dcat = source_dict.get('dcat') or {}
+    themes = set()
+    if source_dict.get('theme'):
+        themes.update(source_dict.get('theme'))
+    if dcat.get('theme'):
+        themes.update(dcat.get('theme'))
+    groups = []
+    for theme in themes:
+        if not theme:
+            continue
+        group_name = converter.munge_tag(theme.lower().replace(' ', '-'))
+        if group_name:
+            groups.append({'name': group_name, 'title': theme})
+    return groups
 
 
 class DataGovHarvester(CustomHarvester):
@@ -352,10 +387,8 @@ class DataGovHarvester(CustomHarvester):
                 name = source_dict.get('slug') or harvest_object.guid
                 package_dict['name'] = self._gen_new_name(name)
 
-            # Ensure source_dict has fields expected by config processors
-            # Copy groups from package_dict (which were mapped from themes) to source_dict
-            # so that RemoteGroups processor can validate them
-            source_dict['groups'] = package_dict.get('groups', [])
+            # Themes → source_dict groups for RemoteGroups (not on package_dict from converter)
+            source_dict['groups'] = _source_groups_from_datagov_themes(source_dict)
 
             # Copy extras from package_dict to source_dict so CompositeMapping and other
             # processors can reference converted fields (e.g., extras.dcat_modified)
@@ -416,7 +449,7 @@ class DataGovHarvester(CustomHarvester):
                 if upload_to_datastore and p.plugin_loaded('xloader'):
                     # Get package dict again in case there's new resource ids
                     pkg_dict = p.toolkit.get_action('package_show')(package_context, {'id': package_id})
-                    upload_resources_to_datastore(package_context, pkg_dict, source_dict, base_search_url)
+                    upload_resources_to_datastore(package_context, pkg_dict)
 
         except Exception as e:
             dataset_name = source_dict.get('slug') or source_dict.get('identifier', '')

--- a/ckanext/custom_harvest/harvesters/package_search.py
+++ b/ckanext/custom_harvest/harvesters/package_search.py
@@ -455,7 +455,7 @@ def copy_across_resource_ids(existing_dataset, harvested_dataset, config=None):
 
 
 def upload_resources_to_datastore(context, package_dict, source_dict, base_search_url):
-    for resource in package_dict.get('resources'):
+    for resource in package_dict.get('resources', []):
         if utils.is_xloader_format(resource.get('format')) and resource.get('id'):
             # Get data dictionary if available and push to datastore
             push_data_dictionary(context, resource, source_dict, base_search_url)
@@ -476,7 +476,7 @@ def upload_resources_to_datastore(context, package_dict, source_dict, base_searc
 def push_data_dictionary(context, resource, source_dict, base_search_url):
     # Check for resource's data dictionary
     fields = []
-    for source_resource in source_dict.get('resources'):
+    for source_resource in source_dict.get('resources', []):
         if (resource.get('url') == source_resource.get('url') and
                 resource.get('title') == source_resource.get('name') and
                 source_resource.get('datastore_active')):

--- a/ckanext/custom_harvest/harvesters/package_search.py
+++ b/ckanext/custom_harvest/harvesters/package_search.py
@@ -470,7 +470,6 @@ def upload_resources_to_datastore(context, package_dict, source_dict, base_searc
                 p.toolkit.get_action('xloader_submit')(context, xloader_dict)
             except p.toolkit.ValidationError as e:
                 log.debug(e)
-                pass
 
 
 def push_data_dictionary(context, resource, source_dict, base_search_url):
@@ -491,7 +490,6 @@ def push_data_dictionary(context, resource, source_dict, base_search_url):
                 break
             except Exception as e:
                 log.debug(e)
-                pass
     # If fields are defined push the data dictionary to datastore
     if fields:
         log.info('Pushing data dictionary for resource '.format(resource.get('id')))
@@ -504,7 +502,6 @@ def push_data_dictionary(context, resource, source_dict, base_search_url):
             p.toolkit.get_action('datastore_create')(context, datastore_dict)
         except Exception as e:
             log.debug(e)
-            pass
 
 class ContentFetchError(Exception):
     pass

--- a/ckanext/custom_harvest/tests/harvesters/test_datagov_harvester.py
+++ b/ckanext/custom_harvest/tests/harvesters/test_datagov_harvester.py
@@ -11,7 +11,10 @@ from ckanext.harvest.model import HarvestObjectExtra
 from ckanext.harvest.tests.lib import run_harvest_job
 import ckanext.harvest.model as harvest_model
 
-from ckanext.custom_harvest.harvesters.datagov import DataGovHarvester
+from ckanext.custom_harvest.harvesters.datagov import (
+    DataGovHarvester,
+    _source_groups_from_datagov_themes,
+)
 from ckanext.custom_harvest.tests.harvesters import mock_datagov
 
 
@@ -399,3 +402,42 @@ class TestDataGovConverter(object):
 
         # Second resource should use accessURL
         assert ckan_dict['resources'][1]['url'] == 'https://example.com/api'
+
+    def test_source_groups_from_datagov_themes_empty(self):
+        assert _source_groups_from_datagov_themes({}) == []
+        assert _source_groups_from_datagov_themes({'dcat': {}}) == []
+
+    def test_source_groups_from_datagov_themes_top_level_and_dcat(self):
+        source_dict = {
+            'theme': ['Climate'],
+            'dcat': {'theme': ['Science']},
+        }
+        groups = _source_groups_from_datagov_themes(source_dict)
+        by_name = {g['name']: g['title'] for g in groups}
+        assert by_name == {'climate': 'Climate', 'science': 'Science'}
+
+    def test_source_groups_from_datagov_themes_dedupes_same_theme_string(self):
+        source_dict = {
+            'theme': ['Climate'],
+            'dcat': {'theme': ['Climate']},
+        }
+        groups = _source_groups_from_datagov_themes(source_dict)
+        assert groups == [{'name': 'climate', 'title': 'Climate'}]
+
+    def test_source_groups_from_datagov_themes_skips_blank_theme(self):
+        source_dict = {'theme': ['', 'Climate']}
+        groups = _source_groups_from_datagov_themes(source_dict)
+        assert groups == [{'name': 'climate', 'title': 'Climate'}]
+
+    def test_source_groups_from_datagov_themes_distinct_strings_same_slug(self):
+        '''Different theme strings can munge to the same group name (RemoteGroups dedupes).'''
+        source_dict = {'theme': ['Economy', 'economy']}
+        groups = _source_groups_from_datagov_themes(source_dict)
+        assert len(groups) == 2
+        assert {g['name'] for g in groups} == {'economy'}
+        assert {g['title'] for g in groups} == {'Economy', 'economy'}
+
+    def test_source_groups_from_datagov_themes_munges_multiword(self):
+        source_dict = {'theme': ['Water Quality']}
+        groups = _source_groups_from_datagov_themes(source_dict)
+        assert groups == [{'name': 'water-quality', 'title': 'Water Quality'}]

--- a/ckanext/custom_harvest/tests/test_configuration_processors.py
+++ b/ckanext/custom_harvest/tests/test_configuration_processors.py
@@ -1031,6 +1031,29 @@ class TestRemoteGroups:
         group_names = sorted([group_dict.get("name") for group_dict in package["groups"]])
         assert group_names == ["climate", "science"]
 
+    def test_modify_package_deduplicates_same_group_name(self):
+        factories.Group(name="economy", title="Economy")
+        package = {
+            "title": "Test Dataset",
+            "name": "test-dataset"
+        }
+        config = {
+            "remote_groups": "only_local"
+        }
+        source_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "groups": [
+                {"name": "economy", "title": "Economy"},
+                {"name": "economy", "title": "economy"},
+            ]
+        }
+
+        self.processor.modify_package_dict(package, config, source_dict)
+
+        group_names = [group_dict.get("name") for group_dict in package["groups"]]
+        assert group_names == ["economy"]
+
 
 class TestResourceFormatOrder:
 

--- a/ckanext/custom_harvest/tests/test_configuration_processors.py
+++ b/ckanext/custom_harvest/tests/test_configuration_processors.py
@@ -132,6 +132,78 @@ class TestDefaultGroups:
         group_names = sorted([group_dict["name"] for group_dict in package["groups"]])
         assert group_names == ["science", "spend-data"]
 
+    def test_modify_package_default_groups_with_name_only_existing_groups(self):
+        package = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "groups": [{"name": "geospatial"}],
+        }
+        config = {
+            "default_groups": ["science", "spend-data"],
+            "default_group_dicts": [
+                {
+                    "id": "b1084f72-292d-11eb-adc1-0242ac120002",
+                    "name": "science",
+                    "title": "Science",
+                    "display_name": "Science",
+                    "is_organization": False,
+                    "type": "group",
+                    "state": "active",
+                },
+                {
+                    "id": "0d7090cc-12c1-4d19-85ba-9bcfc563ab7e",
+                    "name": "spend-data",
+                    "title": "Spend Data",
+                    "display_name": "Spend Data",
+                    "is_organization": False,
+                    "type": "group",
+                    "state": "active",
+                },
+            ],
+        }
+        source_dict = {}
+
+        self.processor.modify_package_dict(package, config, source_dict)
+
+        group_names = sorted([group_dict["name"] for group_dict in package["groups"]])
+        assert group_names == ["geospatial", "science", "spend-data"]
+
+    def test_modify_package_default_groups_skips_duplicate_by_name(self):
+        package = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "groups": [{"name": "science"}],
+        }
+        config = {
+            "default_groups": ["science", "spend-data"],
+            "default_group_dicts": [
+                {
+                    "id": "b1084f72-292d-11eb-adc1-0242ac120002",
+                    "name": "science",
+                    "title": "Science",
+                    "display_name": "Science",
+                    "is_organization": False,
+                    "type": "group",
+                    "state": "active",
+                },
+                {
+                    "id": "0d7090cc-12c1-4d19-85ba-9bcfc563ab7e",
+                    "name": "spend-data",
+                    "title": "Spend Data",
+                    "display_name": "Spend Data",
+                    "is_organization": False,
+                    "type": "group",
+                    "state": "active",
+                },
+            ],
+        }
+        source_dict = {}
+
+        self.processor.modify_package_dict(package, config, source_dict)
+
+        group_names = sorted([group_dict["name"] for group_dict in package["groups"]])
+        assert group_names == ["science", "spend-data"]
+
 
 class TestDefaultExtras:
 


### PR DESCRIPTION
# Description
Fixes Data.gov harvest reliability around groups and datastore upload, and tightens group handling in config processors.

## Changes

- Data.gov themes → groups: DCAT themes are no longer written onto package_dict['groups'] in datagov_to_ckan. Instead, DataGovHarvester builds source_dict['groups'] via _source_groups_from_datagov_themes() so RemoteGroups can resolve memberships using slug + human-readable title.
- RemoteGroups: Iterates source_dict.get('groups', []) so missing groups does not raise KeyError and deduplicate RemoteGroups by slug.
- Data.gov xloader: Implements a local upload_resources_to_datastore(context, package_dict) that only submits resources to xloader; it does not call push_data_dictionary (not applicable to Data.gov Search API payloads).
- Package search harvester: Uses source_dict.get('resources', []) / package_dict.get('resources', []) when iterating so None cannot be iterated.
- Tests: Adds DefaultGroups cases for merging defaults with existing groups (name-only) and skipping duplicates.